### PR TITLE
Feat: 인증 상태 UI변경 로그아웃 기능

### DIFF
--- a/src/apis/userApi.js
+++ b/src/apis/userApi.js
@@ -24,3 +24,17 @@ export const loginUser = async ({ userId, password }) => {
   )
   return response.data
 }
+
+export const getUserInfo = async () => {
+  const response = await axios.get(`${API_URL}/users/me`, {
+    withCredentials: true,
+  })
+  return response.data
+}
+
+export const logoutUser = async () => {
+  const response = await axios.post(`${API_URL}/auth/logout`, null, {
+    withCredentials: true,
+  })
+  return response.data
+}

--- a/src/apis/userApi.js
+++ b/src/apis/userApi.js
@@ -26,7 +26,7 @@ export const loginUser = async ({ userId, password }) => {
 }
 
 export const getUserInfo = async () => {
-  const response = await axios.get(`${API_URL}/users/me`, {
+  const response = await axios.get(`${API_URL}/auth/me`, {
     withCredentials: true,
   })
   return response.data

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,28 +1,22 @@
 import { useState } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
 import Logo from '@/assets/Logo.svg'
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const location = useLocation()
+  const { user, logout } = useAuth()
 
   const isHome = location.pathname === '/'
 
-  // --- 기존 로직 ---
   const headerBgClass = isHome ? 'bg-transparent' : 'bg-white'
   const headerShadow = isHome ? '' : 'shadow-sm'
-
-  // --- ✨ 1. 새로운 동적 클래스 변수 추가 ---
-  // 홈페이지 여부에 따라 텍스트 색상 클래스를 동적으로 할당
   const headerTextColorClass = isHome ? 'text-white' : 'text-text-main'
-  // 홈페이지 여부에 따라 모바일 메뉴 아이콘 색상 클래스를 동적으로 할당
   const menuIconColorClass = isHome ? 'bg-white' : 'bg-black'
-
-  // --- ✨ 2. 활성 링크 스타일 수정 ---
   const navLinkBaseClass = 'hover:text-primary-purple transition-colors duration-200'
-  // 홈페이지에서는 활성 링크 색상이 보라색이 아닌, 부모로부터 상속된 흰색을 사용하도록 수정
   const navLinkActiveClass = isHome
-    ? 'relative font-bold' // 색상 지정을 없애서 부모(text-white) 색을 따르도록 함
+    ? 'relative font-bold'
     : 'text-primary-purple relative font-bold'
 
   const navItems = [
@@ -31,17 +25,20 @@ export default function Header() {
     { to: '/mypage', label: '마이페이지' },
   ]
 
+  const handleLogout = async () => {
+    await logout()
+    setIsMenuOpen(false)
+  }
+
   return (
     <header
       className={`${isHome ? 'absolute' : 'fixed'} top-0 left-0 z-50 w-full ${headerBgClass} ${headerShadow}`}
     >
-      <div className="mx-auto flex h-16 max-w-screen-2xl items-center justify-between px-4 sm:px-6 md:px-8 lg:h-20 lg:px-16">
-        {/* 로고 (모바일) - 로고는 색상이 없으므로 수정 X */}
+      <div className="md:px-8lg:px-16 mx-auto flex h-16 max-w-screen-2xl items-center justify-between px-4 sm:px-6">
         <Link to="/" onClick={() => setIsMenuOpen(false)} className="lg:hidden">
           <img src={Logo} alt="U+NOA 로고" className="h-8" />
         </Link>
 
-        {/* --- ✨ 3. 데스크탑 헤더에 텍스트 색상 적용 --- */}
         <div
           className={`text-card-title ${headerTextColorClass} hidden w-full items-center justify-between lg:flex`}
         >
@@ -62,17 +59,22 @@ export default function Header() {
             ))}
           </div>
 
-          <NavLink
-            to="/login"
-            className={({ isActive }) =>
-              `${navLinkBaseClass} ${isActive ? navLinkActiveClass : ''}`
-            }
-          >
-            로그인
-          </NavLink>
+          {user ? (
+            <button onClick={handleLogout} className={navLinkBaseClass}>
+              로그아웃
+            </button>
+          ) : (
+            <NavLink
+              to="/login"
+              className={({ isActive }) =>
+                `${navLinkBaseClass} ${isActive ? navLinkActiveClass : ''}`
+              }
+            >
+              로그인
+            </NavLink>
+          )}
         </div>
 
-        {/* --- ✨ 4. 모바일 메뉴 버튼에 아이콘 색상 적용 --- */}
         <button
           onClick={() => setIsMenuOpen(!isMenuOpen)}
           className="relative flex h-8 w-8 flex-col items-center justify-center lg:hidden"
@@ -96,6 +98,10 @@ export default function Header() {
         </button>
       </div>
 
+      {isMenuOpen && (
+        <div className="fixed inset-0 z-30 lg:hidden" onClick={() => setIsMenuOpen(false)}></div>
+      )}
+
       {/* 모바일 메뉴 영역 */}
       <div
         className={`absolute top-15 left-0 z-40 w-full overflow-hidden transition-all duration-300 lg:hidden ${
@@ -103,7 +109,6 @@ export default function Header() {
         } ${headerBgClass}`}
         style={{ boxShadow: isMenuOpen ? '0px 2px 4px rgba(0, 0, 0, 0.05)' : 'none' }}
       >
-        {/* --- ✨ 5. 모바일 메뉴에 텍스트 색상 적용 --- */}
         <div
           className={`text-body ${headerTextColorClass} flex flex-col items-start space-y-4 px-6 pt-2 md:px-8 lg:px-16`}
         >
@@ -119,15 +124,22 @@ export default function Header() {
               {label}
             </NavLink>
           ))}
-          <NavLink
-            to="/login"
-            onClick={() => setIsMenuOpen(false)}
-            className={({ isActive }) =>
-              `${navLinkBaseClass} ${isActive ? navLinkActiveClass : ''}`
-            }
-          >
-            로그인
-          </NavLink>
+
+          {user ? (
+            <button onClick={handleLogout} className={navLinkBaseClass}>
+              로그아웃
+            </button>
+          ) : (
+            <NavLink
+              to="/login"
+              onClick={() => setIsMenuOpen(false)}
+              className={({ isActive }) =>
+                `${navLinkBaseClass} ${isActive ? navLinkActiveClass : ''}`
+              }
+            >
+              로그인
+            </NavLink>
+          )}
         </div>
       </div>
     </header>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -5,9 +5,15 @@ const AuthContext = createContext()
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
+  const isAuthenticated = !!user
 
-  const login = userData => {
-    setUser(userData)
+  const login = async () => {
+    try {
+      const userInfo = await getUserInfo()
+      setUser(userInfo)
+    } catch {
+      setUser(null)
+    }
   }
 
   const logout = async () => {
@@ -20,19 +26,14 @@ export function AuthProvider({ children }) {
   }
 
   useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const userInfo = await getUserInfo()
-        setUser(userInfo)
-      } catch {
-        setUser(null)
-      }
-    }
-
-    fetchUser()
+    login()
   }, [])
 
-  return <AuthContext.Provider value={{ user, login, logout }}>{children}</AuthContext.Provider>
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
 }
 
 export function useAuth() {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { getUserInfo, logoutUser } from '@/apis/userApi'
+
+const AuthContext = createContext()
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+
+  const login = userData => {
+    setUser(userData)
+  }
+
+  const logout = async () => {
+    try {
+      await logoutUser()
+      setUser(null)
+    } catch (err) {
+      console.error('로그아웃 실패', err)
+    }
+  }
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const userInfo = await getUserInfo()
+        setUser(userInfo)
+      } catch {
+        setUser(null)
+      }
+    }
+
+    fetchUser()
+  }, [])
+
+  return <AuthContext.Provider value={{ user, login, logout }}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,10 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import router from './routes/index.jsx'
+import AuthProvider from './contexts/AuthContext'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>
 )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import router from './routes/index.jsx'
-import AuthProvider from './contexts/AuthContext'
+import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import ArrowIcon from '@/assets/arrow-right.svg?react'
 import KakaoIcon from '@/assets/kakao-icon.svg'
 import { loginUser } from '@/apis/userApi'
+import { useAuth } from '@/contexts/AuthContext'
 import useToast from '@/hooks/useToast'
 import FormField from '@/components/FormField'
 
@@ -12,6 +13,8 @@ export default function LoginPage() {
 
   const [userIdError, setUserIdError] = useState('')
   const [passwordError, setPasswordError] = useState('')
+
+  const { login } = useAuth()
 
   const navigate = useNavigate()
   const { showErrorToast } = useToast()
@@ -39,10 +42,10 @@ export default function LoginPage() {
 
     try {
       await loginUser({ userId, password })
+      await login()
 
       setUserId('')
       setPassword('')
-
       navigate('/')
     } catch {
       showErrorToast(


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. AuthProvider 설정 및 사용자 인증 API 연동
2. AuthProvider import 방식 및 사용자 정보 API 경로 수정
3. AuthContext 구조 개선 및 인증 상태 플래그 추가
4. Header 컴포넌트에 인증 상태 반영 및 로그아웃 기능 추가
5. 로그인 시 AuthContext의 login 함수 호출로 사용자 정보 동기화

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 사용자 인증 상태 관리를 위한 `AuthContext` 생성 및 전역 적용
- 사용자 정보 API 경로를 `/users/me` → `/auth/me`로 정리하여 역할 분리
- `AuthContext` 내 login 함수 개선 → `getUserInfo()`로 데이터 직접 조회
- `isAuthenticated` 플래그 추가로 인증 여부 명확하게 구분
- Header 컴포넌트에서 인증 상태에 따라 로그인/로그아웃 버튼 분기 처리
- 로그아웃 시 자동으로 사용자 상태 초기화
- 로그인 성공 후 `AuthContext.login()` 호출로 사용자 정보 동기화

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- Header 인증 상태 반영 UI 정상 동작 여부 확인해주세요

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

![로그아웃](https://github.com/user-attachments/assets/308ca376-1b3a-48fa-954d-9178fd583906)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
