### PR TITLE
Feat: 카카오로그인 구현

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -7,6 +7,8 @@ import { useAuth } from '@/contexts/AuthContext'
 import useToast from '@/hooks/useToast'
 import FormField from '@/components/FormField'
 
+const API_URL = import.meta.env.VITE_BACK_URL
+
 export default function LoginPage() {
   const [userId, setUserId] = useState('')
   const [password, setPassword] = useState('')
@@ -55,6 +57,10 @@ export default function LoginPage() {
         </>
       )
     }
+  }
+
+  const handleKakaoLogin = () => {
+    window.location.href = `${API_URL}/api/auth/kakao/login`
   }
 
   return (
@@ -115,6 +121,7 @@ export default function LoginPage() {
 
         <button
           type="button"
+          onClick={handleKakaoLogin}
           className="group bg-kakao relative w-full items-center justify-center rounded-sm py-3 font-semibold sm:rounded-lg sm:py-4"
         >
           <img

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -6,6 +6,8 @@ import { registerUser, checkUserIdDuplicate } from '@/apis/userApi'
 import useToast from '@/hooks/useToast'
 import FormField from '@/components/FormField'
 
+const API_URL = import.meta.env.VITE_BACK_URL
+
 export default function RegisterPage() {
   const [name, setName] = useState('')
   const [userId, setUserId] = useState('')
@@ -121,6 +123,10 @@ export default function RegisterPage() {
     } catch {
       showErrorToast('회원가입에 실패했습니다.')
     }
+  }
+
+  const handleKakaoLogin = () => {
+    window.location.href = `${API_URL}/api/auth/kakao/login`
   }
 
   return (
@@ -261,6 +267,7 @@ export default function RegisterPage() {
 
         <button
           type="button"
+          onClick={handleKakaoLogin}
           className="group bg-kakao relative w-full items-center justify-center rounded-sm py-3 font-semibold sm:rounded-lg sm:py-4"
         >
           <img


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 로그인 및 회원가입 페이지에 카카오 로그인 버튼 기능 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 로그인 페이지에 `카카오 로그인` 버튼 클릭 시 백엔드 카카오 로그인 URL로 이동되도록 `handleKakaoLogin` 함수 추가
- 회원가입 페이지에도 동일한 방식으로 `카카오 로그인` 버튼 처리

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 로컬 환경에서 버튼 클릭 시 백엔드 리다이렉션이 정상 작동하는지 확인해주세요

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

X

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
