### PR TITLE
Fix: chatbot 간단모드 결과

### DIFF
--- a/src/components/ListPage/PlanCard/PlanCard.jsx
+++ b/src/components/ListPage/PlanCard/PlanCard.jsx
@@ -240,12 +240,14 @@ const PlanCard = ({ plan, isCompare = true }) => {
       )}
 
       {/* 버튼 */}
-      <button
-        className="border-primary-purple text-primary-purple hover:bg-gray-30 mt-auto w-full rounded-lg border bg-white px-4 py-3 font-medium transition-colors duration-200"
-        onClick={handleCompare}
-      >
-        비교하기
-      </button>
+      {isCompare && (
+        <button
+          className="border-primary-purple text-primary-purple hover:bg-gray-30 mt-auto w-full rounded-lg border bg-white px-4 py-3 font-medium transition-colors duration-200"
+          onClick={handleCompare}
+        >
+          비교하기
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/chatbot/SimpleMode.jsx
+++ b/src/components/chatbot/SimpleMode.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 
@@ -9,10 +9,16 @@ import NoaYeah from '@/assets/noa-yeah.svg'
 import { SimpleModeForm } from './SimpleModeForm'
 import PlanCard from '../ListPage/PlanCard/PlanCard'
 
-export default function SimpleMode({ sendPromptSilently, messages }) {
+export default function SimpleMode({
+  sendPromptSilently,
+  messages,
+  simpleModeResultMessage,
+  setSimpleModeResultMessage,
+}) {
   const [started, setStarted] = useState(false)
   const [result, setResult] = useState(null)
   const navigate = useNavigate()
+  const [isWaiting, setIsWaiting] = useState(false)
 
   const handleFinish = answers => {
     console.log('사용자 응답:', answers)
@@ -27,16 +33,20 @@ export default function SimpleMode({ sendPromptSilently, messages }) {
 
     const prompt = `${formatted}`.trim()
 
+    setSimpleModeResultMessage(null)
+    setIsWaiting(true)
+
     sendPromptSilently(prompt, 'simple')
   }
 
-  const lastMessage = messages
-    .slice()
-    .reverse()
-    .find(msg => msg.role === 'assistant')
+  useEffect(() => {
+    if (simpleModeResultMessage) {
+      setIsWaiting(false)
+    }
+  }, [simpleModeResultMessage])
+  const lastMessage = simpleModeResultMessage
 
   console.log(lastMessage)
-
   return (
     <>
       {!started ? (
@@ -76,7 +86,9 @@ export default function SimpleMode({ sendPromptSilently, messages }) {
       ) : result ? (
         <div className="relative flex h-full flex-col items-center justify-center px-4 py-10 sm:px-8">
           <div className="absolute z-0 h-[280px] w-[280px] rounded-full bg-gradient-to-br from-[#f3dcff] to-[#ece0ff] opacity-80 blur-3xl" />
-          {lastMessage ? (
+          {isWaiting ? (
+            <p className="z-10 text-gray-500">추천 결과를 기다리고 있어요...</p>
+          ) : lastMessage ? (
             <div className="z-10 flex w-full flex-col items-center gap-y-3">
               <div className="text-text-main text-center">
                 <h2 className="mb-1 text-2xl font-bold">
@@ -97,6 +109,8 @@ export default function SimpleMode({ sendPromptSilently, messages }) {
                 onClick={() => {
                   setStarted(false)
                   setResult(null)
+                  setSimpleModeResultMessage(null)
+                  setIsWaiting(false)
                 }}
                 className="mt-7 max-w-sm rounded-full bg-gray-400 px-6 py-[1.6vh] text-base font-medium text-white sm:w-[50%] sm:py-[1.5vh] sm:text-base"
               >
@@ -109,9 +123,7 @@ export default function SimpleMode({ sendPromptSilently, messages }) {
                 다른 요금제도 볼래요!
               </button>
             </div>
-          ) : (
-            <p className="z-10 text-gray-500">추천 결과를 기다리고 있어요...</p>
-          )}
+          ) : null}
         </div>
       ) : (
         <SimpleModeForm onFinish={handleFinish} />

--- a/src/components/chatbot/SimpleMode.jsx
+++ b/src/components/chatbot/SimpleMode.jsx
@@ -11,7 +11,6 @@ import PlanCard from '../ListPage/PlanCard/PlanCard'
 
 export default function SimpleMode({
   sendPromptSilently,
-  messages,
   simpleModeResultMessage,
   setSimpleModeResultMessage,
 }) {
@@ -84,24 +83,28 @@ export default function SimpleMode({
           </div>
         </div>
       ) : result ? (
-        <div className="relative flex h-full flex-col items-center justify-center px-4 py-10 sm:px-8">
-          <div className="absolute z-0 h-[280px] w-[280px] rounded-full bg-gradient-to-br from-[#f3dcff] to-[#ece0ff] opacity-80 blur-3xl" />
+        <div className="relative flex h-full flex-col items-center justify-center overflow-x-hidden overflow-y-auto px-4 sm:px-6 md:px-8 lg:px-12">
+          <div className="absolute z-0 h-56 w-56 rounded-full bg-gradient-to-br from-[#f3dcff] to-[#ece0ff] opacity-80 blur-3xl sm:h-[220px] sm:w-[220px] md:h-[260px] md:w-[260px] lg:h-[280px] lg:w-[280px]" />
           {isWaiting ? (
-            <p className="z-10 text-gray-500">추천 결과를 기다리고 있어요...</p>
+            <p className="z-10 text-center text-base text-gray-500">
+              추천 결과를 기다리고 있어요...
+            </p>
           ) : lastMessage ? (
-            <div className="z-10 flex w-full flex-col items-center gap-y-3">
+            <div className="absolute top-2 z-10 mt-1 flex w-full flex-col items-center justify-center">
               <div className="text-text-main text-center">
-                <h2 className="mb-1 text-2xl font-bold">
+                <h2 className="text-base font-semibold sm:mb-1 sm:text-xl">
                   NOA가 추천한 요금제예요 <br />
                 </h2>
-                <h3 className="text-xl font-medium text-gray-700">
+                <h3 className="text-sm font-medium text-gray-700 sm:text-base">
                   <strong className="text-primary-purple">라이프스타일</strong>에 꼭 맞는 요금제를
                   찾아왔어요
                 </h3>
               </div>
-              <div className="relative flex">
-                <img src={NoaYeah} alt="" className="absolute -right-35 -bottom-16 z-0 w-45" />
-                <div className="relative z-10">
+              <div className="relative flex flex-col items-center">
+                <div className="absolute -right-18 -bottom-11 z-0 hidden w-36 sm:-right-28 sm:-bottom-16 sm:block sm:w-44">
+                  <img src={NoaYeah} alt="" />
+                </div>
+                <div className="relative z-10 max-w-sm scale-90 sm:w-full sm:scale-90">
                   <PlanCard plan={lastMessage.recommendedPlans[0]} isCompare={false} />
                 </div>
               </div>
@@ -112,13 +115,13 @@ export default function SimpleMode({
                   setSimpleModeResultMessage(null)
                   setIsWaiting(false)
                 }}
-                className="mt-7 max-w-sm rounded-full bg-gray-400 px-6 py-[1.6vh] text-base font-medium text-white sm:w-[50%] sm:py-[1.5vh] sm:text-base"
+                className="z-10 max-w-sm rounded-full bg-gray-400 px-6 py-[1.6vh] text-base font-medium text-white sm:w-[50%] sm:py-[1.5vh] sm:text-base"
               >
                 다시 추천받고 싶어요!
               </button>
               <button
                 onClick={() => navigate('/planlist')}
-                className="bg-primary-purple max-w-sm rounded-full px-6 py-[1.6vh] text-base font-medium text-white sm:w-[50%] sm:py-[1.5vh] sm:text-base"
+                className="bg-primary-purple z-10 mt-1 max-w-sm rounded-full px-6 py-[1.6vh] text-base font-medium text-white sm:w-[50%] sm:py-[1.5vh] sm:text-base"
               >
                 다른 요금제도 볼래요!
               </button>

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -22,6 +22,7 @@ export const useChat = (socket, isConnected) => {
   const [messages, setMessages] = useState([]) // 채팅 화면에 표시될 메시지 배열
   const [isStreaming, setIsStreaming] = useState(false) // AI가 답변을 생성 중인지 여부
   const streamingMessageIdRef = useRef(null) // 스트리밍 중인 AI 메시지의 임시 ID를 추적
+  const [simpleModeResultMessage, setSimpleModeResultMessage] = useState(null)
 
   // --- 소켓 이벤트 리스너 설정 ---
   useEffect(() => {
@@ -73,10 +74,11 @@ export const useChat = (socket, isConnected) => {
     const handleStreamEnd = (data = {}) => {
       // 간단모드 처리
       if (!streamingMessageIdRef.current) {
-        setMessages(prev => [
-          ...prev,
-          { ...data.message, recommendedPlans: data.recommendedPlans, isStreaming: false },
-        ])
+        setSimpleModeResultMessage({
+          ...data.message,
+          recommendedPlans: data.recommendedPlans,
+          isStreaming: false,
+        })
         setIsStreaming(false)
         return
       }
@@ -223,5 +225,7 @@ export const useChat = (socket, isConnected) => {
     addLocalMessage,
     resetConversation,
     sendPromptSilently,
+    simpleModeResultMessage,
+    setSimpleModeResultMessage,
   }
 }

--- a/src/pages/ChatbotPage.jsx
+++ b/src/pages/ChatbotPage.jsx
@@ -15,10 +15,15 @@ function ChatbotPage() {
   const [currentMode, setCurrentMode] = useState('normal')
   const { socket, isConnected } = useSocket()
 
-  const { messages, isStreaming, sendMessage, resetConversation, sendPromptSilently } = useChat(
-    socket,
-    isConnected
-  )
+  const {
+    messages,
+    isStreaming,
+    sendMessage,
+    resetConversation,
+    sendPromptSilently,
+    simpleModeResultMessage,
+    setSimpleModeResultMessage,
+  } = useChat(socket, isConnected)
 
   //useUI는 메시지 변경뿐만 아니라 모드 변경도 감지
   const { messagesEndRef, inputRef, formatTime } = useUI(messages, currentMode)
@@ -67,6 +72,8 @@ function ChatbotPage() {
           messagesEndRef={messagesEndRef}
           inputRef={inputRef}
           sendPromptSilently={sendPromptSilently}
+          simpleModeResultMessage={simpleModeResultMessage}
+          setSimpleModeResultMessage={setSimpleModeResultMessage}
         />
       </div>
     </div>


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 이전 결과가 잠깐 노출되는 현상 해결
2. 간단모드 결과 페이지 반응형 레이아웃 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- PlanCard에서 비교 버튼 조건 추가
- 모바일(375px 이하)에서 배경 이미지가 보이지 않도록 처리
- 화면 크기에 따라 PlanCard, 버튼, 배경 이미지 등이 자연스럽게 보이도록 반응형 레이아웃 적용

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 각자의 환경에서 레이아웃 깨짐 없이 잘 보이는지 확인 부탁드립니다
- 스크롤이 생기는 건 컴포넌트 재사용으로 나타나는 증상입니다
- PlanCard의 비교 버튼이 정상적으로 조건에 따라 보이는지 확인 바랍니다

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
- 모바일
![image](https://github.com/user-attachments/assets/cc4b1adf-9924-4342-81fd-774b9952b822)

- PC
![image](https://github.com/user-attachments/assets/325a8f22-6c3c-4917-b5bc-ae91a30aaa5c)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
