### PR TITLE
Feat: 카카오 회원가입 추가 정보 입력

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.9.0",
         "framer-motion": "^12.18.1",
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.5.2",
@@ -4736,6 +4737,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axios": "^1.9.0",
     "framer-motion": "^12.18.1",
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.5.2",

--- a/src/pages/KakaoExtraInfoPage.jsx
+++ b/src/pages/KakaoExtraInfoPage.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { jwtDecode } from 'jwt-decode'
+import ArrowIcon from '@/assets/arrow-right.svg?react'
+import useToast from '@/hooks/useToast'
+import { useAuth } from '@/contexts/AuthContext'
+
+const API_URL = `${import.meta.env.VITE_BACK_URL}/api`
+
+export default function KakaoExtraInfoPage() {
+  const [isUplus, setIsUplus] = useState('')
+  const [isUplusError, setIsUplusError] = useState('')
+  const navigate = useNavigate()
+
+  const [name, setName] = useState('')
+  const [token, setToken] = useState('')
+
+  const { showDefaultToast, showErrorToast } = useToast()
+
+  const { login } = useAuth()
+
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    const tokenParam = url.searchParams.get('token')
+
+    if (!tokenParam) {
+      showErrorToast('다시 로그인해주세요.')
+      setTimeout(() => navigate('/login'), 1000)
+      return
+    }
+
+    try {
+      const decoded = jwtDecode(tokenParam)
+
+      const currentTime = Date.now() / 1000 // 초 단위
+      if (decoded.exp && decoded.exp < currentTime) {
+        showErrorToast('로그인 시간이 만료되었습니다.')
+        navigate('/login')
+        return
+      }
+
+      setName(decoded.name || '')
+      setToken(tokenParam)
+
+      showDefaultToast('추가로 정보를 입력해주세요.')
+
+      setTimeout(() => {
+        url.searchParams.delete('token')
+        window.history.replaceState({}, '', url)
+      }, 0)
+    } catch {
+      showErrorToast('유효하지 않은 토큰입니다.')
+      navigate('/login')
+    }
+  }, [])
+
+  const handleSubmit = async () => {
+    if (!isUplus) {
+      setIsUplusError('ⓘ LG U+ 요금제 여부를 선택해주세요.')
+      return
+    }
+
+    try {
+      await axios.post(
+        `${API_URL}/auth/kakao/complete`,
+        {
+          token,
+          isUplus,
+        },
+        {
+          withCredentials: true,
+        }
+      )
+
+      await new Promise(resolve => setTimeout(resolve, 300))
+
+      await login()
+
+      showDefaultToast(`${name}님, 환영합니다! 🎉`)
+      navigate('/')
+    } catch (err) {
+      if (err.response?.status === 400) {
+        showErrorToast('로그인 시간이 만료되었습니다.')
+        navigate('/login')
+      } else if (err.response?.status === 409) {
+        showErrorToast('이미 가입된 사용자입니다.')
+        navigate('/login')
+      } else {
+        showErrorToast('가입 처리 중 오류가 발생했습니다.')
+      }
+    }
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-var(--header-height))] flex-col items-center justify-center px-4">
+      <h1 className="text-title sm:text-page-header mb-4 text-center font-bold md:mb-8 md:text-4xl">
+        추가 정보 입력
+      </h1>
+      <p className="md:text-card-title mb-6 text-center">
+        UNOA 사용을 위해 <br className="inline sm:hidden" />
+        <strong className="text-primary-purple">LG U+ 가입 여부</strong>를 확인해주세요.
+      </p>
+
+      <div className="w-full max-w-[320px] space-y-1 sm:max-w-sm sm:space-y-2 md:max-w-md">
+        <div className="mb-1">
+          <label className="ml-2 block"> 가입하신 이름</label>
+          <input
+            type="text"
+            value={name}
+            disabled
+            className="w-full rounded-sm border bg-gray-100 px-4 py-2 text-gray-700 placeholder:text-sm focus:ring-1 sm:rounded-lg sm:px-5 sm:py-4"
+          />
+        </div>
+
+        <div className="mt-10 mb-5 flex flex-col">
+          <div className="flex flex-row justify-center">
+            <span className="text-card-title sm:text-sub-title mb-4 text-center font-medium sm:mb-6">
+              LG U+ 요금제를 사용중이신가요? <span className="text-error">*</span>
+            </span>
+          </div>
+          <div className="flex items-center justify-center gap-10">
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="isUplus"
+                value="yes"
+                checked={isUplus === 'yes'}
+                onChange={() => {
+                  setIsUplus('yes')
+                  setIsUplusError('')
+                }}
+                className="accent-primary-purple"
+              />
+              <span>예</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="isUplus"
+                value="no"
+                checked={isUplus === 'no'}
+                onChange={() => {
+                  setIsUplus('no')
+                  setIsUplusError('')
+                }}
+                className="accent-primary-purple"
+              />
+              <span>아니요</span>
+            </label>
+          </div>
+          <div
+            className={`text-caption sm:text-small-body text-error mt-2 overflow-hidden text-center transition-all duration-300 ease-in-out ${
+              isUplusError ? 'max-h-[100px] opacity-100' : 'max-h-0 opacity-0'
+            }`}
+          >
+            {isUplusError}
+          </div>
+        </div>
+
+        <button
+          onClick={handleSubmit}
+          className="group bg-primary-purple relative mt-4 w-full rounded-sm py-3 font-semibold text-white sm:rounded-lg sm:py-4"
+        >
+          가입 완료
+          <ArrowIcon className="absolute top-1/2 right-4 h-4 w-5 -translate-y-1/2 duration-300 group-hover:translate-x-1" />
+        </button>
+      </div>
+      <footer className="text-text-secondary text-caption sm:text-small-body mt-6 flex w-full max-w-[320px] flex-row justify-between px-2 max-[350px]:flex-col max-[350px]:text-center sm:mt-12 sm:max-w-sm md:max-w-md md:px-6">
+        <p>김현우A | 송은재 | 심영민 | 홍성현 | 황주경</p>
+        <p>© UNOA Corp.</p>
+      </footer>
+    </div>
+  )
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -65,10 +65,10 @@ export default function LoginPage() {
 
   return (
     <div className="flex h-screen flex-col items-center justify-center px-4">
-      <h1 className="text-sub-title sm:text-page-header mb-2 font-bold md:mb-4 md:text-4xl">
+      <h1 className="text-sub-title sm:text-page-header mb-2 text-center font-bold md:mb-4 md:text-4xl">
         UNOA 계정
       </h1>
-      <p className="md:text-card-title mb-4">
+      <p className="md:text-card-title mb-4 text-center">
         아직 UNOA 계정이 없으신가요?
         <Link
           to="/register"
@@ -133,6 +133,10 @@ export default function LoginPage() {
           <ArrowIcon className="absolute top-1/2 right-4 h-4 w-5 -translate-y-1/2 duration-300 group-hover:translate-x-1" />
         </button>
       </form>
+      <footer className="text-text-secondary text-caption sm:text-small-body mt-6 flex w-full max-w-[320px] flex-row justify-between px-2 max-[350px]:flex-col max-[350px]:text-center sm:mt-12 sm:max-w-sm md:max-w-md md:px-6">
+        <p>김현우A | 송은재 | 심영민 | 홍성현 | 황주경</p>
+        <p>© UNOA Corp.</p>
+      </footer>
     </div>
   )
 }

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -130,11 +130,11 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="flex flex-col items-center pt-4 sm:pt-16">
+    <div className="flex flex-col items-center py-4 sm:pt-16">
       <h1 className="text-sub-title sm:text-page-header mb-2 font-bold md:mb-4 md:text-4xl">
         UNOA 계정 생성
       </h1>
-      <p className="md:text-card-title mb-4">
+      <p className="md:text-card-title mb-4 text-center">
         UNOA 계정을 가지고 계시나요?
         <Link
           to="/login"
@@ -279,6 +279,10 @@ export default function RegisterPage() {
           <ArrowIcon className="absolute top-1/2 right-4 h-4 w-5 -translate-y-1/2 duration-300 group-hover:translate-x-1" />
         </button>
       </form>
+      <footer className="text-text-secondary text-caption sm:text-small-body mt-6 flex w-full max-w-[320px] flex-row justify-between px-2 max-[350px]:flex-col max-[350px]:text-center sm:mt-12 sm:max-w-sm md:max-w-md md:px-6">
+        <p>김현우A | 송은재 | 심영민 | 홍성현 | 황주경</p>
+        <p>© UNOA Corp.</p>
+      </footer>
     </div>
   )
 }

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -6,6 +6,7 @@ import PlanListPage from '@/pages/PlanListPage'
 import MyPage from '@/pages/Mypage'
 import RegisterPage from '@/pages/RegisterPage'
 import LoginPage from '@/pages/LoginPage'
+import KakaoExtraInfoPage from '@/pages/KakaoExtraInfoPage'
 
 const router = createBrowserRouter([
   {
@@ -18,6 +19,7 @@ const router = createBrowserRouter([
       { path: 'chatbot', element: <ChatbotPage /> },
       { path: 'planlist', element: <PlanListPage /> },
       { path: 'mypage', element: <MyPage /> },
+      { path: 'kakao-extra-info', element: <KakaoExtraInfoPage /> },
     ],
   },
 ])


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 카카오 회원가입 추가 정보 입력 페이지 라우트 추가
2. 카카오 추가 정보 입력 페이지 구현
3. LoginPage에 footer 추가 및 제목/문구 중앙 정렬 적용
4. RegisterPage에 footer 추가 및 문구 중앙 정렬 개선 

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- `jwt-decode` 패키지 설치 (`jwt` 파싱을 위한 프론트 디코딩 처리용)
- `/kakao-extra-info` 경로 추가로 카카오 회원가입 추가정보 입력 흐름 구축
- `KakaoExtraInfoPage` 구현: 토큰 디코딩, 만료 확인, LG U+ 가입 여부 선택 처리 및 가입 완료 API 연동
- `LoginPage`: footer 추가, 텍스트 중앙 정렬로 UI 일관성 확보
- `RegisterPage`: footer 추가 및 문구 중앙 정렬, padding 개선으로 사용자 경험 향상

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- `jwt-decode` 패키지가 설치되어 있어야 정상 작동하므로 `npm install`  확인 부탁드립니다.
- 카카오 로그인 후 `/kakao-extra-info`로 리디렉션 되는지, 정상 가입 후 홈으로 이동하는지 확인해주세요.
- `LoginPage` 및 `RegisterPage` 하단 UI(footer)가 잘 보이고 정렬되는지 확인해주세요.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

![카카오 회원가입 추가정보](https://github.com/user-attachments/assets/ecdbe01d-d48c-4a7f-86a1-9dae21279a45)

- 회원가입 페이지 Footer 추가
![image](https://github.com/user-attachments/assets/4e9d4c55-4615-49e2-b47c-7bc4dbb8eb99)

- 로그인 페이지 Footer 추가
![image](https://github.com/user-attachments/assets/62f4c51b-1268-4858-af23-2d4d14731d9e)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
