### PR TITLE
Fix: 리스트페이지 스크롤 초기화, Feat: 위로가기 버튼 추가

### DIFF
--- a/src/components/ListPage/PlanCardSystem/PlanCardSystem.jsx
+++ b/src/components/ListPage/PlanCardSystem/PlanCardSystem.jsx
@@ -6,6 +6,7 @@ import PlanGrid from '../PlanGrid/PlanGrid'
 import FilterModal from '../FilterModal/FilterModal'
 import styles from './PlanCardSystem.module.css'
 import LoadingScreen from './../../chatbot/LoadingScreen'
+import ScrollToTopButton from '../../ScrollToTopButton'
 
 const PlanCardSystem = ({ onFilterModalState }) => {
   const [isFilterOpen, setIsFilterOpen] = useState(false)
@@ -243,6 +244,7 @@ const PlanCardSystem = ({ onFilterModalState }) => {
         }}
         onToggleApp={toggleApp}
       />
+      <ScrollToTopButton isOpen={isFilterOpen} />
     </div>
   )
 }

--- a/src/components/ListPage/PlanGrid/PlanGrid.jsx
+++ b/src/components/ListPage/PlanGrid/PlanGrid.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState, useRef } from 'react'
 import PlanCard from '../PlanCard/PlanCard'
 import styles from './PlanGrid.module.css'
 import unoaXimg from '@/assets/유노아x팻말.png'
+
 //요금제 카드 그리드 컴포넌트
 const PlanGrid = ({ plans, onResetFilters, resetTrigger }) => {
   const [visibleCount, setVisibleCount] = useState(6) //초기에 보여줄 카드수
@@ -11,20 +12,30 @@ const PlanGrid = ({ plans, onResetFilters, resetTrigger }) => {
     setVisibleCount(6)
   }, [resetTrigger])
 
-  //현재 보여줄 요금제들
   const visiblePlans = useMemo(() => {
     return plans.slice(0, visibleCount)
   }, [plans, visibleCount])
 
-  //더보기 버튼 클릭 핸들러
   const handleLoadMore = () => {
     setVisibleCount(prev => prev + 6)
   }
 
-  //더 보여줄 요금제가 있는지 확인
-  const hasMore = visibleCount < plans.length
+  const scrollToTop = () => {
+    const overflowContainer = document.querySelector('.overflow-y-auto') //ListPage.jsx에서 준 속성때문에 스크롤이 안되던 현상을 해결
+    if (overflowContainer) {
+      overflowContainer.scrollTo({ top: 0, behavior: 'smooth' })
+      overflowContainer.scrollTop = 0
+    }
 
-  //요금제가 없을 때
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  const handleBackToTop = () => {
+    setVisibleCount(6)
+    scrollToTop()
+  }
+
+  const hasMore = visibleCount < plans.length
   if (plans.length === 0) {
     return (
       <div className={styles.emptyState}>
@@ -61,13 +72,7 @@ const PlanGrid = ({ plans, onResetFilters, resetTrigger }) => {
           <div className={styles.allLoadedMessage}>
             모든 요금제를 확인했습니다 ({plans.length}개)
           </div>
-          <button
-            className={styles.backToTopButton}
-            onClick={() => {
-              setVisibleCount(6)
-              window.scrollTo({ top: 0, behavior: 'smooth' })
-            }}
-          >
+          <button className={styles.backToTopButton} onClick={handleBackToTop}>
             처음으로 돌아가기
           </button>
         </div>

--- a/src/components/PlanCompare/PlanComparePageMobile.jsx
+++ b/src/components/PlanCompare/PlanComparePageMobile.jsx
@@ -252,6 +252,7 @@ const PlanComparePageMobile = () => {
           dragConstraints={{ top: 0, bottom: 0 }}
           dragElastic={0.1}
           onDragEnd={onDragEnd}
+          data-mobile-compare-expanded={isOpen}
         >
           {isOpen ? <ExpandedView /> : <CollapsedView />}
         </motion.div>

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+
+const ScrollToTopButton = () => {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setVisible(window.scrollY > 300)
+    }
+
+    window.addEventListener('scroll', toggleVisibility)
+    return () => window.removeEventListener('scroll', toggleVisibility)
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={`fixed right-4 bottom-4 z-50 rounded-full bg-blue-600 p-3 shadow-lg transition-opacity duration-300 hover:bg-blue-700 sm:right-6 sm:bottom-6 sm:p-4 ${
+        visible ? 'opacity-100' : 'pointer-events-none opacity-0'
+      }`}
+      aria-label="Scroll to top"
+    >
+      {/* Heroicons: chevron-up */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-5 w-5 text-white sm:h-6 sm:w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+      </svg>
+    </button>
+  )
+}
+
+export default ScrollToTopButton

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -42,7 +42,7 @@ const ScrollToTopButton = ({ isOpen }) => {
   return (
     <button
       onClick={scrollToTop}
-      className={`fixed right-4 bottom-4 z-50 rounded-full bg-blue-600 p-3 shadow-lg transition-opacity duration-300 hover:bg-blue-700 sm:right-6 sm:bottom-6 sm:p-4 ${
+      className={`hover:bg-gray-30 fixed right-1.5 bottom-22.5 z-9999 rounded-full border border-gray-200 bg-white p-3 shadow-lg transition-opacity duration-300 sm:right-245.5 sm:bottom-6 sm:p-2 ${
         visible ? 'opacity-100' : 'pointer-events-none opacity-0'
       }`}
       aria-label="Scroll to top"
@@ -50,7 +50,7 @@ const ScrollToTopButton = ({ isOpen }) => {
       {/* Heroicons: chevron-up */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="h-5 w-5 text-white sm:h-6 sm:w-6"
+        className="h-5 w-5 text-black sm:h-6 sm:w-6"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,20 +1,43 @@
 import React, { useEffect, useState } from 'react'
 
-const ScrollToTopButton = () => {
+const ScrollToTopButton = ({ isOpen }) => {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
     const toggleVisibility = () => {
-      setVisible(window.scrollY > 300)
+      const overflowContainer = document.querySelector('.overflow-y-auto')
+
+      if (overflowContainer) {
+        setVisible(overflowContainer.scrollTop > 300)
+      }
     }
 
-    window.addEventListener('scroll', toggleVisibility)
-    return () => window.removeEventListener('scroll', toggleVisibility)
+    toggleVisibility()
+
+    const overflowContainer = document.querySelector('.overflow-y-auto')
+
+    if (overflowContainer) {
+      overflowContainer.addEventListener('scroll', toggleVisibility)
+    }
+
+    return () => {
+      if (overflowContainer) {
+        overflowContainer.removeEventListener('scroll', toggleVisibility)
+      }
+      window.removeEventListener('scroll', toggleVisibility)
+    }
   }, [])
 
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    const overflowContainer = document.querySelector('.overflow-y-auto')
+
+    if (overflowContainer) {
+      overflowContainer.scrollTo({ top: 0, behavior: 'smooth' })
+      overflowContainer.scrollTop = 0
+    }
   }
+
+  if (isOpen) return null
 
   return (
     <button

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,15 +1,18 @@
 import React, { useEffect, useState } from 'react'
 
 const ScrollToTopButton = ({ isOpen }) => {
+  //isOpen은 필터 모달이 띄워졌을때 비활성화 시키기 위해 사용
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
     const toggleVisibility = () => {
       const overflowContainer = document.querySelector('.overflow-y-auto')
+      const containerScrollTop = overflowContainer ? overflowContainer.scrollTop : 0
 
-      if (overflowContainer) {
-        setVisible(overflowContainer.scrollTop > 300)
-      }
+      //모바일을 위한 변수
+      const windowScrollY = window.scrollY || window.pageYOffset || 0
+
+      setVisible(containerScrollTop > 300 || windowScrollY > 300)
     }
 
     toggleVisibility()
@@ -20,6 +23,9 @@ const ScrollToTopButton = ({ isOpen }) => {
       overflowContainer.addEventListener('scroll', toggleVisibility)
     }
 
+    //모바일을 위한 함수 (모바일은 컨테이너가 스크롤 되지 않고 window자체가 스크롤 되기 때문에)
+    window.addEventListener('scroll', toggleVisibility)
+
     return () => {
       if (overflowContainer) {
         overflowContainer.removeEventListener('scroll', toggleVisibility)
@@ -28,6 +34,8 @@ const ScrollToTopButton = ({ isOpen }) => {
     }
   }, [])
 
+  if (isOpen) return null
+
   const scrollToTop = () => {
     const overflowContainer = document.querySelector('.overflow-y-auto')
 
@@ -35,19 +43,17 @@ const ScrollToTopButton = ({ isOpen }) => {
       overflowContainer.scrollTo({ top: 0, behavior: 'smooth' })
       overflowContainer.scrollTop = 0
     }
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
-
-  if (isOpen) return null
 
   return (
     <button
       onClick={scrollToTop}
-      className={`hover:bg-gray-30 fixed right-1.5 bottom-22.5 z-9999 rounded-full border border-gray-200 bg-white p-3 shadow-lg transition-opacity duration-300 sm:right-245.5 sm:bottom-6 sm:p-2 ${
+      className={`hover:bg-gray-30 fixed right-1.5 bottom-22.5 z-9999 rounded-full border border-gray-200 bg-white p-3 shadow-lg transition-opacity duration-300 sm:right-6 sm:bottom-6 sm:p-2 ${
         visible ? 'opacity-100' : 'pointer-events-none opacity-0'
       }`}
       aria-label="Scroll to top"
     >
-      {/* Heroicons: chevron-up */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         className="h-5 w-5 text-black sm:h-6 sm:w-6"


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. PC에서 버튼을 눌러도 스크롤이 맨 위로 올라가지 않던 현상 수정

2. 위로가기 버튼 컴포넌트 추가 

3. 모바일에서 비교하기 화면에 진입 시 위로가기 버튼이 렌더링 되던 현상 수정

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- PlanListPage.jsx에서  `<div className="h-full w-1/2 overflow-y-auto border-r border-gray-200 pt-[60px]"><PlanCardSystem /></div>`가 스크롤을 관리하고 있어서 버튼을 눌러도 스크롤이 위로 올라가지 않았던 것입니다. 해당 클래스가 작성되어있는 요소를 찾고 그 요소의 scrollTop을 0으로 지정해주는 로직을 작성하여 해결하였습니다

- 현우님께서 제공해주신 ScrollToTopButton 를 수정했습니다 스크롤이 300이상일 경우에만 올라가기 버튼이 렌더링 됩니다

- 모바일에서 비교하기 화면 진입시 ScrollToTopButton 이 계속 있던 현상이 있어 이를 수정하기 위해 PlanComparePageMobile.jsx에 한줄 추가했습니다

-필터 버튼을 눌렀을 경우 ScrollToTopButton 이 나타나지 않게 수정했습니다

- ### **ScrollToTopButton.jsx에 작성되어있는 로직들은 리스트페이지에서만 사용되는 로직이니 단순 사용은 상관 없을겁니다**

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 스크롤 잘 올라가나 확인 부탁드립니다

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

1.  PC에서 처음으로 돌아가기 버튼을 눌러도 스크롤이 맨 위로 올라가지 않던 현상 수정
![처음으로돌아가기](https://github.com/user-attachments/assets/d22386dd-57c1-4e99-8b05-65bb04f045e8)


2. 위로가기 컴포넌트 추가 (PC)
![위로가기 버튼](https://github.com/user-attachments/assets/d37ca3bd-e593-47f6-8704-6308ab84eafb)

모바일
![모바일 올라가기](https://github.com/user-attachments/assets/d71b85e0-795e-474f-9446-95b2c767695f)

3. 비교하기 기능 진입 시 버튼 비활성화
![비교활성화시버튼x](https://github.com/user-attachments/assets/90b8e48c-fb6a-4aa9-b20f-a61bfbfd32a7)

4. PlanComparePageMobile.jsx 수정사항
![image](https://github.com/user-attachments/assets/44dbf80e-2b47-46ef-9a4d-559553860ad6)
강조되어있는 부분 한줄 추가

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
