### PR TITLE
Refactor: 마이페이지 혜택

### DIFF
--- a/src/apis/userApi.js
+++ b/src/apis/userApi.js
@@ -39,13 +39,12 @@ export const logoutUser = async () => {
   return response.data
 }
 
-export const getUserBenefits = async name => {
-  const response = await axios.get(`${API_URL}/user/benefits/${name}`, null, {
+export const getUserBenefits = async id => {
+  const response = await axios.get(`${API_URL}/user/benefits/${id}`, null, {
     withCredentials: true,
   })
   return response.data
 }
-
 
 export const changePassword = async ({ newPassword }) => {
   const response = await axios.post(

--- a/src/components/Modal/GradeGuideModal.jsx
+++ b/src/components/Modal/GradeGuideModal.jsx
@@ -1,5 +1,5 @@
 import Modal from './Modal'
-import GradeCard from '@/components/Benefits/GradeCard'
+import GradeCard from '@/components/MyPage/GradeCard'
 
 const membershipGrades = [
   {

--- a/src/components/MyPage/GradeCard.jsx
+++ b/src/components/MyPage/GradeCard.jsx
@@ -1,4 +1,4 @@
-export default function GradeCard({ imageSrc, grade, condition, color }) {
+export default function GradeCard({ imageSrc, grade, condition }) {
   const gradeColorMap = {
     VVIP: '#e6007e',
     VIP: '#e062a7',

--- a/src/components/MyPage/UserBenefits.jsx
+++ b/src/components/MyPage/UserBenefits.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
-import { getUserBenefits } from '@/apis/userApi'
-import ArrowIcon from '@/assets/arrow-right.svg?react'
 import { useAuth } from '@/contexts/AuthContext'
+import { getUserBenefits } from '@/apis/userApi'
 import LoadingScreen from '@/components/chatbot/LoadingScreen'
+import ArrowIcon from '@/assets/arrow-right.svg?react'
 
-export const UserBenefitsSection = () => {
+export const UserBenefits = () => {
   const [membershipBenefits, setMembershipBenefits] = useState([])
   const [longTermBenefits, setLongTermBenefits] = useState([])
   const [planBenefits, setPlanBenefits] = useState({})

--- a/src/components/MyPage/UserBenefits.jsx
+++ b/src/components/MyPage/UserBenefits.jsx
@@ -28,7 +28,7 @@ export const UserBenefits = () => {
   useEffect(() => {
     const fetchBenefits = async () => {
       try {
-        const res = await getUserBenefits(user.user.name)
+        const res = await getUserBenefits(user.user._id)
         setMembershipBenefits(res.membershipBenefits)
         setLongTermBenefits(res.longTermBenefits)
         setPlanBenefits(res.planBenefits)

--- a/src/components/MyPage/UserPlan.jsx
+++ b/src/components/MyPage/UserPlan.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { logoutUser, changePassword } from '@/apis/userApi'
 import ChangePasswordModal from '@/components/MyPage/ChangePasswordModal'
-import GradeGuideModal from '../Modal/GradeGuideModal'
+import GradeGuideModal from '@/components/Modal/GradeGuideModal'
 import useToast from '@/hooks/useToast'
 
 export default function UserPlan() {

--- a/src/components/MyPage/UserPlan.jsx
+++ b/src/components/MyPage/UserPlan.jsx
@@ -3,13 +3,16 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { logoutUser, changePassword } from '@/apis/userApi'
 import ChangePasswordModal from '@/components/MyPage/ChangePasswordModal'
+import GradeGuideModal from '../Modal/GradeGuideModal'
 import useToast from '@/hooks/useToast'
 
 export default function UserPlan() {
   const { user } = useAuth()
 
   const navigate = useNavigate()
-  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
+  const [isGradeModalOpen, setIsGradeModalOpen] = useState(false)
 
   const { showSuccessToast, showErrorToast } = useToast()
   const formatPrice = price => {
@@ -70,13 +73,16 @@ export default function UserPlan() {
         <div className="flex flex-row gap-2 max-[540px]:flex-col">
           {user.user.userId && (
             <button
-              onClick={() => setIsModalOpen(true)}
+              onClick={() => setIsPasswordModalOpen(true)}
               className="border-border text-small-body sm:text-body hover:text-primary-purple rounded-sm border px-2 py-2 transition-colors duration-300 sm:px-6"
             >
               비밀번호 변경
             </button>
           )}
-          <button className="border-border text-small-body sm:text-body rounded-sm border px-2 py-2 sm:px-6">
+          <button
+            onClick={() => setIsGradeModalOpen(true)}
+            className="border-border text-small-body sm:text-body hover:text-primary-purple rounded-sm border px-2 py-2 sm:px-6"
+          >
             등급기준 안내
           </button>
         </div>
@@ -128,11 +134,15 @@ export default function UserPlan() {
           )}
         </div>
       </div>
-      {isModalOpen && (
+      {isPasswordModalOpen && (
         <ChangePasswordModal
-          onClose={() => setIsModalOpen(false)}
+          onClose={() => setIsPasswordModalOpen(false)}
           onSubmit={handlePasswordChange}
         />
+      )}
+
+      {isGradeModalOpen && (
+        <GradeGuideModal isOpen={isGradeModalOpen} onClose={() => setIsGradeModalOpen(false)} />
       )}
     </div>
   )

--- a/src/components/chatbot/SimpleMode.jsx
+++ b/src/components/chatbot/SimpleMode.jsx
@@ -7,7 +7,7 @@ import HandImg from '@/assets/hand-sign.svg'
 import NoaYeah from '@/assets/noa-yeah.svg'
 
 import { SimpleModeForm } from './SimpleModeForm'
-import PlanCard from '../ListPage/PlanCard/PlanCard'
+import PlanCard from '@/components/ListPage/PlanCard/PlanCard'
 
 export default function SimpleMode({
   sendPromptSilently,

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -3,7 +3,7 @@ import UserNoPlan from '@/components/MyPage/UserNoPlan'
 import UserPlan from '@/components/MyPage/UserPlan'
 import NoUser from '@/components/MyPage/NoUser'
 import NoPlanBenefit from '@/components/MyPage/NoPlanBenefit'
-import { UserBenefitsSection } from '@/components/Benefits/UserBenefitsSection'
+import { UserBenefits } from '@/components/MyPage/UserBenefits'
 import Footer from '@/components/Footer'
 
 export default function MyPage() {
@@ -21,7 +21,7 @@ export default function MyPage() {
     content = (
       <>
         <UserPlan />
-        <UserBenefitsSection />
+        <UserBenefits />
       </>
     )
   } else {


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 마이페이지에 등급 기준 안내 모달 추가
2. 비밀번호 변경/등급기준 안내 모달 상태 분리
3. 컴포넌트 이름 및 디렉토리 구조 변경
4. 사용자 이름 기반 혜택 조회를 _id 기반으로 변경

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 마이페이지에서 등급 기준 안내 버튼 클릭 시 GradeGuideModal이 열리도록 기능 추가
- 기존 비밀번호 변경 모달과 등급 기준 모달의 상태를 개별 useState로 분리하여 관리
- 사용자 이름으로 혜택 정보를 가져오던 것을 _id 기반으로 변경

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 마이페이지에서 두 모달이 정상적으로 열리고 닫히는지 확인 부탁드립니다

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![마이페이지_모달](https://github.com/user-attachments/assets/78bfb10f-5b0a-40f2-a342-c2a52541a8f4)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
