### PR TITLE
Refactor: 탭 방식으로 변경

### DIFF
--- a/src/components/MyPage/UserBenefits.jsx
+++ b/src/components/MyPage/UserBenefits.jsx
@@ -4,6 +4,18 @@ import { getUserBenefits } from '@/apis/userApi'
 import LoadingScreen from '@/components/chatbot/LoadingScreen'
 import ArrowIcon from '@/assets/arrow-right.svg?react'
 
+const categoryOrder = [
+  '푸드',
+  '문화/여가',
+  '생활/편의',
+  '엑티비티',
+  '쇼핑',
+  '여행/교통',
+  '뷰티/건강',
+  '교육',
+  'APP/기기',
+]
+
 export const UserBenefits = () => {
   const [membershipBenefits, setMembershipBenefits] = useState([])
   const [longTermBenefits, setLongTermBenefits] = useState([])
@@ -11,7 +23,7 @@ export const UserBenefits = () => {
   const [benefitPages, setBenefitPages] = useState({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  const [openCategories, setOpenCategories] = useState({})
+  const [activeTab, setActiveTab] = useState(categoryOrder[0])
 
   const imageCategories = ['프리미엄', '미디어']
   const itemsPerPage = 3
@@ -50,12 +62,10 @@ export const UserBenefits = () => {
     return acc
   }, {})
 
-  const toggleCategory = category => {
-    setOpenCategories(prev => ({
-      ...Object.fromEntries(Object.keys(prev).map(k => [k, false])),
-      [category]: !prev[category],
-    }))
-  }
+  const sorted = categoryOrder.reduce((acc, key) => {
+    if (groupedMembership[key]) acc[key] = groupedMembership[key]
+    return acc
+  }, {})
 
   const paginate = (category, direction, total) => {
     setBenefitPages(prev => {
@@ -70,37 +80,30 @@ export const UserBenefits = () => {
     <div className="border-border w-[85%] overflow-hidden rounded-xl border bg-white px-5 py-10 lg:w-[70%] 2xl:w-[50%]">
       <section>
         <h2 className="mb-3 text-lg font-bold">멤버십 혜택</h2>
-        {Object.entries(groupedMembership).map(([category, benefits]) => (
-          <div key={category} className="mb-5">
+        <div className="mb-4 flex flex-wrap gap-2">
+          {Object.keys(sorted).map(category => (
             <button
-              onClick={() => toggleCategory(category)}
-              className={`flex w-full items-center gap-4 rounded text-left text-base font-medium transition-colors ${
-                openCategories[category] ? 'text-primary-purple' : 'text-text-main'
+              key={category}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                activeTab === category ? 'bg-primary-purple text-white' : 'bg-gray-50 text-gray-600'
               }`}
+              onClick={() => setActiveTab(category)}
             >
-              <ArrowIcon className={`h-3 w-3 ${openCategories[category] ? 'rotate-90' : ''}`} />
-              {category}
+              {categoryLabels[category] || category}
             </button>
-            {openCategories[category] && (
-              <div className="mt-2 grid grid-cols-1 gap-4 px-2 sm:grid-cols-4">
-                {benefits.map((b, idx) => (
-                  <div
-                    key={idx}
-                    className="border-gray-90 flex items-center gap-4 rounded-xl border p-4"
-                  >
-                    <div className="flex flex-col gap-y-1.5">
-                      <img src={`/images/benefits/${b.brand.toLowerCase()}.png`} className="w-9" />
-                      <p className="text-base font-bold">{b.brand}</p>
-                      <p className="text-sm break-keep whitespace-normal text-gray-700">
-                        {b.benefit}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+          ))}
+        </div>
+        <div className="grid grid-cols-1 gap-4 px-2 sm:grid-cols-4">
+          {sorted[activeTab].map((b, idx) => (
+            <div key={idx} className="border-gray-90 flex items-center gap-4 rounded-xl border p-4">
+              <div className="flex flex-col gap-y-1.5">
+                <img src={`/images/benefits/${b.brand.toLowerCase()}.png`} className="w-9" />
+                <p className="text-base font-bold">{b.brand}</p>
+                <p className="text-sm break-keep whitespace-normal text-gray-700">{b.benefit}</p>
               </div>
-            )}
-          </div>
-        ))}
+            </div>
+          ))}
+        </div>
       </section>
 
       <section className="mt-6">


### PR DESCRIPTION
- 카테고리 순서 지정

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1.  멤버십 혜택 UI를 기존 토글 방식에서 탭 방식으로 변경
2. 카테고리 출력 순서 변경

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- UserBenefits 컴포넌트 내 멤버십 혜택 섹션을 탭 UI로 리팩토링
- 카테고리 순서를 지정(푸드, 문화/여가, 생활/편의, 엑티비티, 쇼핑, 여행/교통, 뷰티/건강, 교육, APP/기기) 순서로 출력
- 기존의 toggle 상태 관리를 activeTab 방식으로 변경하여 UX 향상

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 탭 전환 시 정상적으로 해당 혜택이 표시되는지 확인 부탁드립니다.
- 지정한 카테고리 순서대로 잘 나오는지 확인해주세요.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![탭메뉴](https://github.com/user-attachments/assets/cb8454cc-d4b2-4338-80ce-7f2de91db459)
![탭메뉴_모바일](https://github.com/user-attachments/assets/502262ed-6ba2-45c7-a166-00177ee65f44)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
