### PR TITLE
Fix: 요금제 혜택 UI 조건 수정

### DIFF
--- a/src/components/MyPage/UserBenefits.jsx
+++ b/src/components/MyPage/UserBenefits.jsx
@@ -116,14 +116,19 @@ export const UserBenefits = () => {
                 className="border-gray-90 flex h-full flex-col rounded-xl border px-4 py-5"
               >
                 <h3 className="mb-2 text-base font-semibold">
-                  {categoryLabels[category] || category}
+                  {(categoryLabels[category] || category).replace(
+                    /\(택1\)/,
+                    benefits.length === 1 ? '' : '(택1)'
+                  )}
                 </h3>
                 {imageCategories.includes(category) ? (
                   <div className="flex items-center justify-between gap-3">
                     <button
                       onClick={() => paginate(category, 'prev')}
                       disabled={(benefitPages[category] || 0) === 0}
-                      className="text-sm text-gray-500 disabled:opacity-30"
+                      className={`text-sm text-gray-500 disabled:opacity-30 ${
+                        benefits.length <= 3 ? 'invisible' : ''
+                      }`}
                     >
                       <ArrowIcon className="rotate-180" />
                     </button>
@@ -136,7 +141,7 @@ export const UserBenefits = () => {
                         .map((b, idx) => (
                           <li key={idx}>
                             <img
-                              src={`/images/icons/${b.benefit}.png`}
+                              src={`/images/icons/${b.benefit.trim()}.png`}
                               alt={b.benefit}
                               className="w-16 sm:w-16"
                             />
@@ -148,7 +153,9 @@ export const UserBenefits = () => {
                       disabled={
                         ((benefitPages[category] || 0) + 1) * itemsPerPage >= benefits.length
                       }
-                      className="text-sm text-gray-500 disabled:opacity-30"
+                      className={`text-sm text-gray-500 disabled:opacity-30 ${
+                        benefits.length <= 3 ? 'invisible' : ''
+                      }`}
                     >
                       <ArrowIcon />
                     </button>


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. benefit 문자열 앞뒤 공백 제거로 이미지 경로 오류 해결
2. 혜택 개수 4개 이상일 때만 양쪽 버튼 노출되도록 조건 처리
3. 혜택이 1개일 경우 '(택1)' 문구 제거 처리


## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 이미지가 로드되지 않는 문제는 benefit 문자열의 앞뒤 공백으로 인해 발생했으며, .trim()을 적용해 해결함
- 양쪽 이동 버튼(prev/next)은 혜택 개수가 4개 이상일 경우에만 visible 상태로 표시되도록 조건 추가
- categoryLabels에 포함된 '(택1)' 문구는 혜택 개수가 1개일 때 표시되지 않도록 정규표현식을 이용해 동적으로 제거 처리

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 각자의 요금제에서 카테고리별 혜택 이미지가 정상적으로 표시되는지 확인해주세요
- prev/next 버튼이 혜택이 4개 이상일 때만 보이는지 확인해주세요
- '(택1)' 문구가 혜택이 2개 이상일 때만 보이는지 확인 부탁드립니다- 

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![image](https://github.com/user-attachments/assets/96225822-c3b2-4559-9cbd-8cd6d85faf18)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨