### PR TITLE
Fix: 5G/LTE 외 탭 눌렀을 경우 나이대 정렬 비활성화

### DIFF
--- a/src/components/ListPage/FilterSort/FilterSort.jsx
+++ b/src/components/ListPage/FilterSort/FilterSort.jsx
@@ -7,6 +7,7 @@ const FilterSort = ({
   onAgeGroupChange,
   currentSort,
   currentAgeGroup,
+  selectedCategory,
 }) => {
   const [isSortOpen, setIsSortOpen] = useState(false)
   const [isAgeOpen, setIsAgeOpen] = useState(false)
@@ -29,7 +30,7 @@ const FilterSort = ({
     { value: '30', label: '30대' },
     { value: '40', label: '40대' },
     { value: '50', label: '50대' },
-    { value: '60', label: '60대' },
+    { value: '60', label: '60대 이상' },
   ]
 
   //외부 클릭시 드롭다운 닫기
@@ -99,30 +100,32 @@ const FilterSort = ({
           )}
         </div>
         {/* 나이대 드롭다운 */}
-        <div className={styles.dropdown} ref={ageRef}>
-          <button className={styles.dropdownButton} onClick={() => setIsAgeOpen(!isAgeOpen)}>
-            {getCurrentAgeLabel()}
-            <span className={`${styles.arrow} ${isAgeOpen ? styles.arrowUp : ''}`}>
-              <img src="../../../images/icons/down_arrow.png" alt="아래화살표" />
-            </span>
-          </button>
+        {selectedCategory !== '5G/LTE 요금제' ? null : (
+          <div className={styles.dropdown} ref={ageRef}>
+            <button className={styles.dropdownButton} onClick={() => setIsAgeOpen(!isAgeOpen)}>
+              {getCurrentAgeLabel()}
+              <span className={`${styles.arrow} ${isAgeOpen ? styles.arrowUp : ''}`}>
+                <img src="../../../images/icons/down_arrow.png" alt="아래화살표" />
+              </span>
+            </button>
 
-          {isAgeOpen && (
-            <div className={styles.dropdownMenu}>
-              {ageOptions.map(option => (
-                <button
-                  key={option.value}
-                  className={`${styles.dropdownItem} ${
-                    currentAgeGroup === option.value ? styles.activeItem : ''
-                  }`}
-                  onClick={() => handleAgeSelect(option.value)}
-                >
-                  {option.label}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+            {isAgeOpen && (
+              <div className={styles.dropdownMenu}>
+                {ageOptions.map(option => (
+                  <button
+                    key={option.value}
+                    className={`${styles.dropdownItem} ${
+                      currentAgeGroup === option.value ? styles.activeItem : ''
+                    }`}
+                    onClick={() => handleAgeSelect(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <button onClick={onFilterOpen} className={styles.filterLink}>

--- a/src/components/ListPage/PlanCardSystem/PlanCardSystem.jsx
+++ b/src/components/ListPage/PlanCardSystem/PlanCardSystem.jsx
@@ -138,17 +138,22 @@ const PlanCardSystem = ({ onFilterModalState }) => {
     //나이대 필터 적용
     if (currentAgeGroup !== 'all') {
       sortedPlans = sortedPlans.filter(plan => {
-        if (!plan.ageGroup) return false
+        if (
+          !plan.ageGroup ||
+          plan.ageGroup === 'all' ||
+          plan.ageGroup === '전체' ||
+          plan.ageGroup === '' ||
+          plan.ageGroup === null
+        ) {
+          return true
+        }
 
         const planAge = parseInt(plan.ageGroup)
         const filterAge = parseInt(currentAgeGroup)
 
-        // 나이대 범위 매칭 (±5년 범위)
         if (currentAgeGroup === '60') {
-          // 60대 이상
           return planAge >= 60
         } else {
-          // 20대, 30대, 40대, 50대
           return planAge >= filterAge && planAge < filterAge + 10
         }
       })
@@ -207,6 +212,7 @@ const PlanCardSystem = ({ onFilterModalState }) => {
         />
 
         <FilterSort
+          selectedCategory={appliedFilters.category}
           onFilterOpen={() => setIsFilterOpen(true)}
           onSortChange={handleSortChange}
           onAgeGroupChange={handleAgeGroupChange}


### PR DESCRIPTION
1. 5G/LTE 탭에서만 나이대 정렬 드롭다운이 활성화

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 5G/LTE 외 탭 눌렀을 경우 나이대 정렬 비활성화

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 5G/LTE 외 탭 눌렀을 경우 나이대 정렬 비활성화 처리 했습니다

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- x

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

![정렬](https://github.com/user-attachments/assets/fe8d9b8f-1a7c-41dc-80c2-f68234df0a2f)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
